### PR TITLE
Set과 Map까지 사용가능한 DeepCopy

### DIFF
--- a/__test__/deepClone.test.ts
+++ b/__test__/deepClone.test.ts
@@ -1,0 +1,48 @@
+import deepCopy from "../deepCopy";
+
+describe("deepClone test", () => {
+  test("Array test", () => {
+    const originalArray = [1, 2, 3];
+    const clonedArray = deepCopy(originalArray);
+    originalArray[0] = 10;
+    expect(originalArray[0]).toBe(10);
+    expect(clonedArray[0]).toBe(1);
+  });
+
+  test("Map test", () => {
+    const originalMap: Map<"key1" | "key2", { value: number }> = new Map();
+    originalMap.set("key1", { value: 1 });
+    originalMap.set("key2", { value: 2 });
+
+    const clonedMap = deepCopy(originalMap);
+    originalMap.set("key1", { value: 10 });
+
+    expect(originalMap.get("key1")?.value).toBe(10);
+    expect(clonedMap.get("key1")?.value).toBe(1);
+  });
+
+  test("Set test", () => {
+    const originalSet: Set<{ data: number }> = new Set();
+    originalSet.add({ data: 1 });
+    originalSet.add({ data: 2 });
+
+    const clonedSet: Set<{ data: number }> = deepCopy(originalSet);
+    originalSet.forEach((item) => (item.data = 10));
+
+    expect(originalSet.values().next().value.data).toBe(10);
+    expect(clonedSet.values().next().value.data).toBe(1);
+  });
+
+  test("Object test", () => {
+    const originalObject = {
+      a: 1,
+      b: 2,
+      c: 3,
+    };
+
+    const clonedObject = deepCopy(originalObject);
+    originalObject.a = 10;
+    expect(originalObject.a).toBe(10);
+    expect(clonedObject.a).toBe(1);
+  });
+});

--- a/__test__/deepCloneArray.test.ts
+++ b/__test__/deepCloneArray.test.ts
@@ -1,0 +1,35 @@
+import { deepCloneArray } from "../deepCopy/array";
+
+describe("copyArrayDeep deep copy array", () => {
+  test("copyArrayDeep test number array", () => {
+    const arrNumber = [1, 2, 3];
+    const clonedArrNumber = deepCloneArray(arrNumber);
+    arrNumber[0] = 10;
+    expect(arrNumber[0]).toBe(10);
+    expect(clonedArrNumber[0]).toBe(1);
+  });
+
+  test("copyArrayDeep test string array", () => {
+    const arrString = ["a", "b", "c"];
+    const clonedArrString = deepCloneArray(arrString);
+    arrString[0] = "d";
+    expect(arrString[0]).toBe("d");
+    expect(clonedArrString[0]).toBe("a");
+  });
+
+  test("copyArrayDeep test object array", () => {
+    const arrObject = [{ a: 1 }, { b: 2 }, { c: 3 }];
+    const clonedArrObject = deepCloneArray(arrObject);
+    arrObject[0] = { a: 3 };
+    expect(arrObject[0]).toEqual({ a: 3 });
+    expect(clonedArrObject[0]).toEqual({ a: 1 });
+  });
+
+  test("copyArrayDeep test boolean array", () => {
+    const arrBoolean = [true, false, true];
+    const clonedArrBoolean = deepCloneArray(arrBoolean);
+    arrBoolean[0] = false;
+    expect(arrBoolean[0]).toEqual(false);
+    expect(clonedArrBoolean[0]).toEqual(true);
+  });
+});

--- a/__test__/deepCloneMap.test.ts
+++ b/__test__/deepCloneMap.test.ts
@@ -1,0 +1,15 @@
+import { deepCloneMap } from "../deepCopy/map";
+
+describe("copyMapDeep deep copy Map", () => {
+  test("copyMapDeep test Map", () => {
+    const originalMap = new Map();
+    originalMap.set("key1", { value: 1 });
+    originalMap.set("key2", { value: 2 });
+
+    const clonedMap = deepCloneMap(originalMap);
+    originalMap.set("key1", { value: 10 });
+
+    expect(originalMap.get("key1")?.value).toBe(10);
+    expect(clonedMap.get("key1")?.value).toBe(1);
+  });
+});

--- a/__test__/deepCloneObject.test.ts
+++ b/__test__/deepCloneObject.test.ts
@@ -1,0 +1,19 @@
+import { deepCloneObject } from "../deepCopy/object";
+
+describe("copyObjectDeep deep copy object", () => {
+  test("copyObjectDeep test object of number value", () => {
+    const objNumber = { a: 1, b: 2, c: 3 };
+    const clonedObjNumber = deepCloneObject(objNumber);
+    objNumber.a = 10;
+    expect(objNumber.a).toBe(10);
+    expect(clonedObjNumber.a).toBe(1);
+  });
+
+  test("copyObjectDeep test object of string value", () => {
+    const objString = { a: "a", b: "b", c: "c" };
+    const clonedObjString = deepCloneObject(objString);
+    objString.a = "d";
+    expect(objString.a).toBe("d");
+    expect(clonedObjString.a).toBe("a");
+  });
+});

--- a/__test__/deepCloneSet.test.ts
+++ b/__test__/deepCloneSet.test.ts
@@ -1,0 +1,15 @@
+import { deepCloneSet } from "../deepCopy/set";
+
+describe("copySetDeep deep copy Set", () => {
+  test("copySetDeep test Set", () => {
+    const originalSet = new Set<{ value: number }>();
+    originalSet.add({ value: 1 });
+    originalSet.add({ value: 2 });
+
+    const clonedSet = deepCloneSet(originalSet);
+    originalSet.forEach((item) => (item.value = 10));
+
+    expect(originalSet.values().next().value.value).toBe(10);
+    expect(clonedSet.values().next().value.value).toBe(1);
+  });
+});

--- a/deepCopy/array.ts
+++ b/deepCopy/array.ts
@@ -1,0 +1,17 @@
+export const deepCloneArray = (target: any): any => {
+  if (Array.isArray(target)) {
+    return deepCopyArray(target, deepCloneArray);
+  }
+  return target;
+};
+
+export const deepCopyArray = <T>(
+  target: any,
+  deepCopy: (value: T) => T
+): any => {
+  let clone = [];
+  for (let i = 0; i < target.length; i++) {
+    clone[i] = deepCopy(target[i]);
+  }
+  return clone;
+};

--- a/deepCopy/index.ts
+++ b/deepCopy/index.ts
@@ -1,0 +1,30 @@
+import { deepCopyArray } from "./array";
+import { deepCopyMap } from "./map";
+import { deepCopyObject } from "./object";
+import { deepCopySet } from "./set";
+
+const deepCopy = <T>(target: T): T => {
+  if (typeof target !== "object" || target === null) {
+    return target;
+  }
+
+  if (Array.isArray(target)) {
+    return deepCopyArray(target, deepCopy) as T;
+  }
+
+  if (target instanceof Map) {
+    return deepCopyMap(target, deepCopy) as T;
+  }
+
+  if (target instanceof Set) {
+    return deepCopySet(target, deepCopy) as T;
+  }
+
+  if (typeof target === "object" && target !== null) {
+    return deepCopyObject(target, deepCopy) as T;
+  }
+
+  return target;
+};
+
+export default deepCopy;

--- a/deepCopy/map.ts
+++ b/deepCopy/map.ts
@@ -1,0 +1,19 @@
+export const deepCloneMap = <T>(target: T): T => {
+  if (target instanceof Map) {
+    return deepCopyMap(target, deepCloneMap) as T;
+  }
+  return target;
+};
+
+export const deepCopyMap = <T>(
+  target: Map<any, any>,
+  deepCopy: (value: T) => T
+) => {
+  let clone = new Map();
+  //* key: key로 넣은 값 반환
+  //* innerValue: key로 넣은 값의 value 반환
+  target.forEach((innerValue, key) => {
+    clone.set(deepCopy(key), deepCopy(innerValue));
+  });
+  return clone;
+};

--- a/deepCopy/object.ts
+++ b/deepCopy/object.ts
@@ -9,7 +9,7 @@ export const deepCopyObject = <T>(target: T, deepCopy: (value: any) => T) => {
   //* Object.getPrototypeOf() 메서드는 지정된 객체의 프로토타입(가령 내부 [[Prototype]] 속성값)을 반환합니다.
   const clone = Object.create(Object.getPrototypeOf(target));
   for (let key in target) {
-    if (target.hasOwnProperty(key)) {
+    if (target?.hasOwnProperty && target.hasOwnProperty(key)) {
       clone[key] = deepCopy(target[key]);
     }
   }

--- a/deepCopy/object.ts
+++ b/deepCopy/object.ts
@@ -1,0 +1,17 @@
+export const deepCloneObject = <T>(target: T): T => {
+  if (typeof target !== "object" || target === null) {
+    return target;
+  }
+  return deepCopyObject(target, deepCloneObject) as T;
+};
+
+export const deepCopyObject = <T>(target: T, deepCopy: (value: any) => T) => {
+  //* Object.getPrototypeOf() 메서드는 지정된 객체의 프로토타입(가령 내부 [[Prototype]] 속성값)을 반환합니다.
+  const clone = Object.create(Object.getPrototypeOf(target));
+  for (let key in target) {
+    if (target?.hasOwnProperty && target.hasOwnProperty(key)) {
+      clone[key] = deepCopy(target[key]);
+    }
+  }
+  return clone;
+};

--- a/deepCopy/object.ts
+++ b/deepCopy/object.ts
@@ -9,7 +9,7 @@ export const deepCopyObject = <T>(target: T, deepCopy: (value: any) => T) => {
   //* Object.getPrototypeOf() 메서드는 지정된 객체의 프로토타입(가령 내부 [[Prototype]] 속성값)을 반환합니다.
   const clone = Object.create(Object.getPrototypeOf(target));
   for (let key in target) {
-    if (target?.hasOwnProperty && target.hasOwnProperty(key)) {
+    if (target.hasOwnProperty(key)) {
       clone[key] = deepCopy(target[key]);
     }
   }

--- a/deepCopy/set.ts
+++ b/deepCopy/set.ts
@@ -1,0 +1,28 @@
+import { deepCopyObject } from "./object";
+
+export const deepCloneSet = <T>(target: T): T => {
+  if (target instanceof Set) {
+    return deepCopySet(target, deepCloneSet);
+  }
+
+  if (typeof target === "object" && target !== null) {
+    return deepCopyObject(target, deepCloneSet);
+  }
+
+  return target;
+};
+
+export const deepCopySet = <T>(
+  target: Set<T>,
+  deepCopy: (value: T) => T
+): T => {
+  let clone = new Set();
+  target.forEach((value) => {
+    if (value instanceof Object) {
+      clone.add(deepCopy(value));
+    } else {
+      clone.add(value);
+    }
+  });
+  return clone as T;
+};

--- a/package.json
+++ b/package.json
@@ -16,6 +16,6 @@
     "typescript": "^5.1.6"
   },
   "scripts": {
-    "test": "jest"
+    "test": "jest --watchAll --verbose"
   }
 }


### PR DESCRIPTION
deepCopy를 잘 구현한 lodash의 deepClone을 보고 안에 구조를 살펴보았는데, lodash에서는 복사를 위해서 Symbol 및 다양하게 사용한 것을 보고 그대로 구현해도 이해가 되지 않을 것 같아서, 참고만 하였습니다. 
[getSymbolsIn](https://github.com/lodash/lodash/blob/master/.internal/getSymbolsIn.js) 에서 `Object.getPrototypeOf()` 을 사용하여서 프로토타입을 복사하는 것을 보고 참고하여 추가하였습니다.